### PR TITLE
Remove custom HTTP client configuration from example

### DIFF
--- a/examples/llm.py
+++ b/examples/llm.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 
-import httpx
 from dotenv import load_dotenv
 from openai import OpenAI
 
@@ -20,7 +19,6 @@ def main() -> None:
             "HTTP-Referer": "https://github.com/llm-tool-selection",
             "X-Title": "llm-tool-selection",
         },
-        http_client=httpx.Client(trust_env=False),
     )
     model = os.getenv("MODEL_NAME", "openai/gpt-4o-mini")
     completion = client.chat.completions.create(


### PR DESCRIPTION
## Summary
- drop custom httpx client so environment proxy settings are honored

## Testing
- `OPENAI_API_KEY=dummy uv run examples/llm.py` (fails with 401 AuthenticationError)

------
https://chatgpt.com/codex/tasks/task_e_68b9bca57130832b8353d1f4b301169a