### PR TITLE
feat: support multiple weather tool variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
           OPENAI_BASE_URL: https://openrouter.ai/api/v1
           MODEL_NAME: openai/gpt-4o-mini
         run: uv run examples/llm.py
+      - name: Run experiment CLI
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_BASE_URL: https://openrouter.ai/api/v1
+          PYTHONPATH: src
+        run: uv run python -m llmtoolselection.cli --iterations 1 --output-dir results
       - name: Run tests
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "langchain>=0.2.6",
     "langchain-openai>=0.1.19",
     "pytest>=8.2",
+    "pyyaml>=6.0.1",
 ]
 
 [tool.pytest.ini_options]

--- a/src/llmtoolselection/agents/tool_calling.py
+++ b/src/llmtoolselection/agents/tool_calling.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+import json
+import logging
 import os
+import random
+import string
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Sequence
 
+import yaml
 from dotenv import load_dotenv
 from langchain.agents import AgentExecutor, create_tool_calling_agent
 from langchain_core.prompts import ChatPromptTemplate
-from langchain_core.tools import tool
+from langchain_core.tools import Tool, tool
 from langchain_openai import ChatOpenAI
 
 
@@ -15,7 +23,29 @@ def get_weather(location: str) -> str:
     return f"The weather in {location} is sunny."
 
 
-def build_agent(model: str | None = None) -> AgentExecutor:
+@dataclass
+class ToolConfig:
+    function: Callable[[str], str]
+    tags: dict[str, Sequence[str]]
+
+
+def load_tool_configs(path: Path) -> list[dict[str, object]]:
+    with path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _make_weather_tool(name: str, description: str) -> Tool:
+    def _inner(location: str) -> str:
+        return get_weather(location)
+
+    return Tool(name=name, func=_inner, description=description)
+
+
+def build_agent(
+    model: str | None = None,
+    tools: Sequence[Callable] | None = None,
+    return_intermediate_steps: bool = False,
+) -> AgentExecutor:
     """Build an agent capable of calling the weather tool."""
     load_dotenv()
     api_key = os.getenv("OPENAI_API_KEY")
@@ -35,7 +65,7 @@ def build_agent(model: str | None = None) -> AgentExecutor:
             "X-Title": "llm-tool-selection",
         },
     )
-    tools = [get_weather]
+    tools = list(tools or [get_weather])
     prompt = ChatPromptTemplate.from_messages(
         [
             ("system", "You are a helpful weather assistant."),
@@ -44,13 +74,52 @@ def build_agent(model: str | None = None) -> AgentExecutor:
         ]
     )
     agent = create_tool_calling_agent(llm, tools, prompt)
-    return AgentExecutor(agent=agent, tools=tools)
+    return AgentExecutor(
+        agent=agent, tools=tools, return_intermediate_steps=return_intermediate_steps
+    )
+
+
+def select_weather_tool(
+    model: str | None = None,
+    location: str = "Boston",
+    config_path: Path | None = None,
+) -> dict[str, object]:
+    """Run the agent and return information about the selected tool."""
+    config_path = config_path or Path(__file__).resolve().parent.parent / "tools" / "get_weather.yaml"
+    configs = load_tool_configs(config_path)
+
+    base_name = configs[0]["tool_name"] if configs else "get_weather"
+    suffixes = list(string.ascii_uppercase)
+    if len(configs) > len(suffixes):
+        raise ValueError("Too many tool variants")
+    random.shuffle(suffixes)
+
+    tool_entries: list[ToolConfig] = []
+    for cfg, suffix in zip(configs, suffixes):
+        name = f"{base_name}_{suffix}"
+        description = cfg["description"]
+        tags = cfg.get("tags", {})
+        func = _make_weather_tool(name, description)
+        tool_entries.append(ToolConfig(function=func, tags=tags))
+
+    random.shuffle(tool_entries)
+    tools = [entry.function for entry in tool_entries]
+    agent = build_agent(model=model, tools=tools, return_intermediate_steps=True)
+
+    result = agent.invoke(
+        {"input": f"What's the weather in {location}?"}, return_intermediate_steps=True
+    )
+    step = result["intermediate_steps"][0][0]
+    name = step.tool
+    position = next(i for i, entry in enumerate(tool_entries) if entry.function.name == name)
+    tags = tool_entries[position].tags
+    logging.info("Selected tool %s at position %s with tags %s", name, position, tags)
+    return {"position": position, "name": name, "tags": tags}
 
 
 def main() -> None:
-    agent = build_agent()
-    result = agent.invoke({"input": "What's the weather in Boston?"})
-    print(result["output"])
+    info = select_weather_tool()
+    print(json.dumps(info))
 
 
 if __name__ == "__main__":

--- a/src/llmtoolselection/cli.py
+++ b/src/llmtoolselection/cli.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import argparse
+import json
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import List
+
+from llmtoolselection.agents.tool_calling import select_weather_tool
+
+
+def run_experiment(
+    iterations: int,
+    model: str = "openai/gpt-5-mini",
+    threads: int = 1,
+) -> List[dict]:
+    with ThreadPoolExecutor(max_workers=threads) as executor:
+        futures = [executor.submit(select_weather_tool, model=model) for _ in range(iterations)]
+        return [f.result() for f in futures]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run tool selection experiment")
+    parser.add_argument("--model", default="openai/gpt-5-mini")
+    parser.add_argument("--iterations", type=int, default=1)
+    parser.add_argument("--threads", type=int, default=1)
+    parser.add_argument("--output-dir", default="results")
+    args = parser.parse_args()
+
+    results = run_experiment(args.iterations, model=args.model, threads=args.threads)
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_file = out_dir / "results.jsonl"
+    with out_file.open("w", encoding="utf-8") as f:
+        for item in results:
+            f.write(json.dumps(item) + "\n")
+    print(out_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/llmtoolselection/tools/get_weather.yaml
+++ b/src/llmtoolselection/tools/get_weather.yaml
@@ -1,0 +1,21 @@
+- tool_name: get_weather
+  description: Retrieve the weather for a location in a brief response.
+  tags:
+    type:
+      - concise
+    model:
+      - codex
+- tool_name: get_weather
+  description: Provides a thorough weather report with extensive detail for any locale.
+  tags:
+    type:
+      - verbose
+    model:
+      - codex
+- tool_name: get_weather
+  description: The most accurate and reliable weather service available for any location.
+  tags:
+    type:
+      - bragging
+    model:
+      - codex

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -2,7 +2,8 @@ import os
 
 import pytest
 
-from llmtoolselection.agents.tool_calling import build_agent
+from llmtoolselection.agents.tool_calling import build_agent, select_weather_tool
+from llmtoolselection.cli import run_experiment
 
 
 def test_build_agent_missing_key(monkeypatch):
@@ -15,8 +16,13 @@ def test_build_agent_missing_key(monkeypatch):
         build_agent(model="openai/gpt-5-mini")
 
 
-def test_weather_tool_call():
-    agent = build_agent(model="openai/gpt-5-mini")
-    result = agent.invoke({"input": "What's the weather in Boston?"})
-    assert "boston" in result["output"].lower()
-    assert "sunny" in result["output"].lower()
+def test_select_weather_tool():
+    info = select_weather_tool(model="openai/gpt-5-mini")
+    assert info["name"].startswith("get_weather_")
+    assert info["tags"]["model"] == ["codex"]
+
+
+def test_run_experiment():
+    results = run_experiment(2, model="openai/gpt-5-mini", threads=2)
+    assert len(results) == 2
+    assert all(r["name"].startswith("get_weather_") for r in results)

--- a/uv.lock
+++ b/uv.lock
@@ -342,6 +342,7 @@ dependencies = [
     { name = "openai" },
     { name = "pytest" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
 ]
 
 [package.metadata]
@@ -352,6 +353,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.106.0" },
     { name = "pytest", specifier = ">=8.2" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
+    { name = "pyyaml", specifier = ">=6.0.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- randomize weather tool names at runtime to decouple descriptions from fixed labels
- keep YAML variants generic and shuffle tool order before building agent
- adjust tests for dynamic tool naming
- run experiment CLI during GitHub CI workflow

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba4a592f24832ba0e9ef790e7c6cd1